### PR TITLE
RPI and Network load optimisation

### DIFF
--- a/MMM-Sonos.js
+++ b/MMM-Sonos.js
@@ -4,6 +4,7 @@
  * By Christopher Fenner https://github.com/CFenner
  * MIT Licensed.
  */
+ 
  Module.register('MMM-Sonos', {
 	defaults: {
 		showStoppedRoom: true,
@@ -18,17 +19,69 @@
 	},
 	start: function() {
 		Log.info('Starting module: ' + this.name);
+		
+		var ModuleSonosHidden = false; 
+		var UserPresence = true;
+		var updateIntervalID = 0;
+		
 		this.update();
 		// refresh every x minutes
-		setInterval(
+		this.updateIntervalID = setInterval(
 			this.update.bind(this),
 			this.config.updateInterval * 60 * 1000);
 	},
-	update: function(){
+	update: function(){		
+	//	Log.log("Update SONOS demandée !");		
 		this.sendSocketNotification(
 			'SONOS_UPDATE',
 			this.config.apiBase + ":" + this.config.apiPort + "/" + this.config.apiEndpoint);
 	},
+	
+	//Modif AgP42 - 16/07/2018	
+
+	suspend: function() {
+		this.ModuleSonosHidden = true; //Il aurait été plus propre d'utiliser this.hidden, mais comportement aléatoire...
+		//Log.log("Fct suspend - ModuleHidden = " + ModuleHidden);
+		this.GestionUpdateIntervalSonos(); //on appele la fonction qui gere tous les cas
+	},
+	
+	resume: function() {
+		this.ModuleSonosHidden = false;
+		//Log.log("Fct resume - ModuleHidden = " + ModuleHidden);
+		this.GestionUpdateIntervalSonos();	
+	},
+
+	notificationReceived: function(notification, payload) {
+		if (notification === "USER_PRESENCE") { // notification envoyée par le module MMM-PIR-Sensor. Voir sa doc
+			//Log.log("Fct notificationReceived USER_PRESENCE - payload = " + payload);
+			UserPresence = payload;
+			this.GestionUpdateIntervalSonos();
+		}
+	},
+
+	GestionUpdateIntervalSonos: function() {
+		if (UserPresence === true && this.ModuleSonosHidden === false){ // on s'assure d'avoir un utilisateur présent devant l'écran (sensor PIR) et que le module soit bien affiché
+			var self = this;
+			Log.log(this.name + " est revenu et user present ! On update");
+	
+			// update tout de suite
+			this.update();
+			//et on remet l'intervalle d'update en route, si aucun deja actif (pour éviter les instances multiples)
+			if (this.updateIntervalID === 0){
+						
+				this.updateIntervalID = setInterval(
+					this.update.bind(this),
+					this.config.updateInterval * 60 * 1000);
+			}
+		}else{ //sinon (UserPresence = false OU ModuleHidden = true)
+			Log.log("Personne regarde : on stop l'update Sonos !");
+			clearInterval(this.updateIntervalID); // on arrete l'intervalle d'update en cours
+			this.updateIntervalID=0; //on reset la variable
+		}
+	},
+
+	//fin modif AgP
+	
 	render: function(data){
 		var text = '';
 		$.each(data, function (i, item) {

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 This is an adaption of the [MagicMirror-SonosModule](https://github.com/Vaggan/MagicMirror-SonosModule) by [Vaggan](https://github.com/Vaggan). It was modified to fit the new module system and got some enhancements in visualisation an configuration.
 
+In order to limit RPI load and reduce network request, this module is not updated when the MMM-Sonos is not displayed on the mirror (hidden by MMM-Remote-Control or any Carousel module for example). It is also not updated in case the notification "USER_PRESENCE=false" is received. This notification can be send by the use of a PIR sensor and the module MMM-PIR-Sensor. 
+
 ![Sonos Module](https://github.com/CFenner/MagicMirror-Sonos-Module/blob/master/.github/preview.png)
 
 ## Usage

--- a/node_helper.js
+++ b/node_helper.js
@@ -14,7 +14,7 @@ module.exports = NodeHelper.create({
   //Subclass socketNotificationReceived received.
   socketNotificationReceived: function(notification, url) {
     if (notification === 'SONOS_UPDATE') {
-      console.log(notification);
+   //   console.log(notification);
       var self = this;
       request(url, function(error, response, body) {
         if (!error && response.statusCode == 200) {


### PR DESCRIPTION
Allows to stop Sonos Module update when the module MMM-Sonos is not displayed to the user (because hidden or notification "USER_PRESENCE" = false received from PIS-Sensor for example). 
Immediate update requested when the module is displayed again or user present again. 
No impact for user and no configuration changes. 

Tested on a RPI2 with MM v2.4.1