### PR TITLE
Provide artBase URL in config to load album art correctly

### DIFF
--- a/MMM-Sonos.js
+++ b/MMM-Sonos.js
@@ -11,6 +11,7 @@
 		showRoomName: true,
 		animationSpeed: 1000,
 		updateInterval: 0.5, // every 0.5 minutes
+		artBase: '',
 		apiBase: 'http://localhost',
 		apiPort: 5005,
 		apiEndpoint: 'zones',
@@ -50,7 +51,8 @@
 				var currentTrack = item.coordinator.state.currentTrack;
 				var artist = currentTrack.artist;
 				var track = currentTrack.title;
-				var cover = currentTrack.absoluteAlbumArtUri;
+				var cover = currentTrack.albumArtUri;
+				cover = cover ? cover : currentTrack.absoluteAlbumArtUri;
 				var streamInfo = currentTrack.streamInfo;
 				var type = currentTrack.type;
 
@@ -70,6 +72,9 @@
 		artist = artist?artist:"";
 		track = track?track:"";
 		cover = cover?cover:"";
+		if (cover.substring(0, 6) === '/getaa') {
+			cover = this.config.artBase + cover;
+		}
 		var room = '';
 		// if Sonos Playbar is in TV mode, no title is provided and therefore the room should not be displayed
 		var isEmpty = (artist && artist.trim().length) == 0


### PR DESCRIPTION
The underlying node-sonos-http-api API sometimes returns relative urls for album art, which can't be loaded in all circumstances.  See https://github.com/jishi/node-sonos-http-api/issues/673

This change allows you to provide a config option for a base URL for the art to load from.  Put this in your MMM-Sonos config section in config.js:

```
artBase: 'http://10.107.0.50:1400'
```

where that is the IP of a Sonos device on your network. It doesn't need to be one in the group playing.

This is working for me on my install - tested with, TuneIn, Spotify, SoundCloud, Audible, Plex and the local music library.